### PR TITLE
Remove archive product and blend opportunities

### DIFF
--- a/src/stapi_fastapi_umbra/client.py
+++ b/src/stapi_fastapi_umbra/client.py
@@ -1,0 +1,92 @@
+import asyncio
+import json
+
+import httpx
+from stapi_fastapi.models.opportunity import Opportunity, OpportunityRequest
+
+from stapi_fastapi_umbra.models import FeasibilityResponse
+from stapi_fastapi_umbra.opportunities import (
+    feasibility_response_to_opportunity_list,
+    opportunity_request_to_feasibility_request,
+    stac_item_to_opportunity,
+)
+from stapi_fastapi_umbra.settings import Settings
+
+settings = Settings.load()
+
+
+class AuthorizationError(Exception):
+    pass
+
+
+class Client:
+    def __init__(self, authorization: str | None) -> None:
+        self.authorization = authorization
+
+    async def get_opportunities_from_archive(
+        self,
+        search: OpportunityRequest,
+    ) -> list[Opportunity]:
+        # Gets opportunities from the archive. Only point geometry searches
+        # are supported for now.
+
+        request_payload = {"filter-lang": "cql2-json", **search.model_dump()}
+
+        # SearchOpportunity requires a `geometry` field, but the Canopy API archive/search
+        # route uses an optional 'intersects' field.
+        request_payload["intersects"] = request_payload.pop("geometry")
+
+        res = httpx.post(url=settings.stac_url, json=request_payload)
+        res.raise_for_status()
+        opportunities = [
+            stac_item_to_opportunity(o, product_id=search.product_id)
+            for o in res.json()["features"]
+        ]
+        return opportunities
+
+    async def get_opportunities_from_feasibility(
+        self,
+        search: OpportunityRequest,
+    ) -> list[Opportunity]:
+        # Gets opportunities from feasibility. Only point geometry searches
+        # are supported.
+
+        if not self.authorization:
+            raise AuthorizationError(
+                "Time range requested includes future opportunities, authorization is required"
+            )
+
+        headers = {"Authorization": self.authorization}
+
+        payload = opportunity_request_to_feasibility_request(search)
+        payload_to_send = payload.model_dump_json()
+
+        feasibility_post = httpx.post(
+            url=settings.feasibility_url,
+            json=json.loads(payload_to_send),
+            headers=headers,
+        )
+
+        feasibility_post.raise_for_status()
+        request_id = feasibility_post.json()["id"]
+        i = 0
+        while i <= settings.feasibility_timeout:
+            feasibility_get = httpx.get(
+                url=f"{settings.feasibility_url}/{request_id}",
+                headers=headers,
+            )
+            feasibility_get.raise_for_status()
+            feasibility_status = feasibility_get.json()["status"]
+
+            if feasibility_status == "COMPLETED":
+                break
+            await asyncio.sleep(1)
+
+        feasibility_response = FeasibilityResponse.model_validate(
+            feasibility_get.json()
+        )
+        opportunities = feasibility_response_to_opportunity_list(
+            feasibility_response, product_id=search.product_id
+        )
+
+        return opportunities

--- a/src/stapi_fastapi_umbra/opportunities.py
+++ b/src/stapi_fastapi_umbra/opportunities.py
@@ -2,6 +2,7 @@ from geojson_pydantic import Point
 from stapi_fastapi.models.opportunity import (Opportunity,
                                               OpportunityProperties,
                                               OpportunityRequest)
+
 # from stapi_fastapi_umbra.products import SpotlightConstraints
 from stapi_fastapi_umbra.models import (FeasibilityRequest,
                                         FeasibilityResponse, ImagingMode,

--- a/src/stapi_fastapi_umbra/products.py
+++ b/src/stapi_fastapi_umbra/products.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from stapi_fastapi.models.product import Product, Provider, ProviderRole
 from stapi_fastapi.models.shared import Link
 
-from .parameters import UmbraArchiveParameters, UmbraSpotlightParameters
+from .parameters import UmbraSpotlightParameters
 
 
 class SceneSizeConstraints(Enum):
@@ -45,10 +45,12 @@ canopy_docs_link = Link(
 
 
 SPOTLIGHT_PRODUCT = Product(
-    conformsTo=["https://geojson.org/schema/Point.json"],
+    conformsTo=[
+        "https://geojson.org/schema/Point.json",
+    ],
     id="umbra_spotlight",
     title="Umbra Spotlight Task",
-    description="Spotlight images served by creating new Orders.",
+    description="Spotlight images served by creating new Orders or retrieving existing images from the archive.",
     keywords=["sar", "radar", "umbra", "spotlight"],
     license="CC-BY-4.0",
     providers=[umbra_provider],
@@ -56,18 +58,4 @@ SPOTLIGHT_PRODUCT = Product(
     parameters=UmbraSpotlightParameters,
 )
 
-ARCHIVE_PRODUCT = Product(
-    conformsTo=[
-        "https://geojson.org/schema/Polygon.json",
-        "https://geojson.org/schema/MultiPolygon.json",
-    ],
-    id="umbra_archive_catalog",
-    title="Umbra Archive Catalog",
-    description="Umbra SAR Images served by the Archive Catalog.",
-    keywords=["sar", "radar", "umbra", "catalog", "archive"],
-    license="CC-BY-4.0",
-    providers=[umbra_provider],
-    links=[canopy_docs_link],
-    parameters=UmbraArchiveParameters,
-)
-PRODUCTS = [SPOTLIGHT_PRODUCT, ARCHIVE_PRODUCT]
+PRODUCTS = [SPOTLIGHT_PRODUCT]


### PR DESCRIPTION
Removes the separate `ARCHIVE_PRODUCT` and instead blends opportunities from both the archice and future feasibility depending on the datetime range requested.